### PR TITLE
Add CLI doctor command for AI crawler access

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import { defineConfig } from "astro/config";
 
 export default defineConfig({
 	site: "https://docs.aeorank.dev",
@@ -49,6 +49,7 @@ export default defineConfig({
 					label: "CLI Reference",
 					items: [
 						{ label: "scan", slug: "cli/scan" },
+						{ label: "doctor", slug: "cli/doctor" },
 						{ label: "compare", slug: "cli/compare" },
 						{ label: "init", slug: "cli/init" },
 						{ label: "Configuration", slug: "cli/configuration" },

--- a/apps/docs/src/content/docs/cli/doctor.md
+++ b/apps/docs/src/content/docs/cli/doctor.md
@@ -1,0 +1,51 @@
+---
+title: "aeorank doctor"
+description: Diagnose AI crawler access, WAF blocks, and llms.txt reachability.
+---
+
+The `doctor` command checks whether common AI crawlers can reach a site without
+being blocked by `robots.txt`, bot mitigation, or common `/llms.txt` firewall
+responses.
+
+## Usage
+
+```bash
+npx aeorank-cli doctor https://example.com
+```
+
+## What it checks
+
+- Fetches `/robots.txt` and reports every crawler from AEOrank's core AI crawler
+  list as `allowed`, `blocked`, or `unspecified`.
+- Sends a `HEAD` request to the target URL using each crawler as the
+  `User-Agent`.
+- Sends a `HEAD` request to `/llms.txt` using each crawler as the `User-Agent`.
+- Flags explicit Cloudflare and AWS WAF headers: `cf-mitigated` and
+  `x-amzn-waf-action`.
+- Treats common access-control status codes like `403`, `429`, and `503` as
+  possible blocks, while avoiding false positives for missing `/llms.txt` files
+  or servers that do not support `HEAD`.
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format <type>` | `human` | Output format: `human` or `json` |
+| `--timeout <ms>` | `10000` | Per-request timeout in milliseconds |
+
+## Examples
+
+### Human output
+
+```bash
+npx aeorank-cli doctor https://example.com
+```
+
+### JSON output
+
+```bash
+npx aeorank-cli doctor https://example.com --format json
+```
+
+The JSON output includes the normalized target URL, checked file URLs, per-crawler
+diagnostics, WAF header signals, and a final verdict.

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,0 +1,185 @@
+import { AI_CRAWLERS } from "@aeorank/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { doctorCommand, renderDoctorReport, runDoctor } from "../commands/doctor.js";
+
+vi.mock("ora", () => ({
+	default: () => ({
+		start: vi.fn().mockReturnThis(),
+		stop: vi.fn().mockReturnThis(),
+		succeed: vi.fn().mockReturnThis(),
+		fail: vi.fn().mockReturnThis(),
+		text: "",
+	}),
+}));
+
+describe("doctor command", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("reports robots blocks, HEAD status, /llms.txt status, and WAF signals per crawler", async () => {
+		const fetchMock = makeFetchMock({
+			robots: ["User-agent: GPTBot", "Disallow: /", "", "User-agent: ClaudeBot", "Allow: /"].join(
+				"\n",
+			),
+			targetByUserAgent: {
+				GPTBot: { status: 403, headers: { "cf-mitigated": "challenge" } },
+			},
+			llmsByUserAgent: {
+				GPTBot: { status: 403 },
+			},
+		});
+
+		const report = await runDoctor("https://example.com", {
+			fetchImpl: fetchMock,
+			timeoutMs: 1000,
+		});
+
+		expect(report.crawlers).toHaveLength(AI_CRAWLERS.length);
+
+		const gptBot = report.crawlers.find((crawler) => crawler.userAgent === "GPTBot");
+		expect(gptBot?.robots).toBe("blocked");
+		expect(gptBot?.target.status).toBe(403);
+		expect(gptBot?.target.blocked).toBe(true);
+		expect(gptBot?.target.wafSignals).toEqual([{ header: "cf-mitigated", value: "challenge" }]);
+		expect(gptBot?.llmsTxt.blocked).toBe(true);
+
+		const claudeBot = report.crawlers.find((crawler) => crawler.userAgent === "ClaudeBot");
+		expect(claudeBot?.robots).toBe("allowed");
+		expect(claudeBot?.target.status).toBe(200);
+
+		expect(report.verdict.status).toBe("fail");
+		expect(report.verdict.summary).toContain("1 crawler");
+	});
+
+	it("does not flag 404 /llms.txt or 405 HEAD responses as firewall blocks", async () => {
+		const fetchMock = makeFetchMock({
+			robots: "User-agent: *\nAllow: /",
+			defaultTarget: { status: 405 },
+			defaultLlms: { status: 404 },
+		});
+
+		const report = await runDoctor("https://example.com", {
+			fetchImpl: fetchMock,
+			timeoutMs: 1000,
+		});
+
+		expect(report.verdict.status).toBe("pass");
+		for (const crawler of report.crawlers) {
+			expect(crawler.robots).toBe("allowed");
+			expect(crawler.target.blocked).toBe(false);
+			expect(crawler.llmsTxt.blocked).toBe(false);
+			expect(crawler.target.wafSignals).toHaveLength(0);
+			expect(crawler.llmsTxt.wafSignals).toHaveLength(0);
+		}
+	});
+
+	it("renders a human-readable table with crawler and WAF details", async () => {
+		const report = await runDoctor("https://example.com", {
+			fetchImpl: makeFetchMock({
+				robots: "User-agent: GPTBot\nDisallow: /",
+				targetByUserAgent: {
+					GPTBot: { status: 403, headers: { "x-amzn-waf-action": "BLOCK" } },
+				},
+			}),
+			timeoutMs: 1000,
+		});
+
+		const output = stripAnsi(renderDoctorReport(report));
+
+		expect(output).toContain("AI crawler doctor");
+		expect(output).toContain("Crawler");
+		expect(output).toContain("GPTBot");
+		expect(output).toContain("robots.txt");
+		expect(output).toContain("x-amzn-waf-action=BLOCK");
+		expect(output).toContain("Verdict: FAIL");
+	});
+
+	it("prints JSON from the command action", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeFetchMock({
+				robots: "User-agent: *\nAllow: /",
+				defaultTarget: { status: 200 },
+				defaultLlms: { status: 404 },
+			}),
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await doctorCommand.parseAsync(["node", "doctor", "https://example.com", "--format", "json"]);
+
+		const jsonCall = logSpy.mock.calls.find((call) => {
+			try {
+				const parsed = JSON.parse(String(call[0]));
+				return parsed.url === "https://example.com/";
+			} catch {
+				return false;
+			}
+		});
+
+		expect(jsonCall).toBeTruthy();
+		const parsed = JSON.parse(String(jsonCall?.[0]));
+		expect(parsed.verdict.status).toBe("pass");
+		expect(parsed.crawlers).toHaveLength(AI_CRAWLERS.length);
+	});
+});
+
+interface MockResponseSpec {
+	status: number;
+	headers?: Record<string, string>;
+}
+
+interface MockFetchOptions {
+	robots: string | null;
+	defaultTarget?: MockResponseSpec;
+	defaultLlms?: MockResponseSpec;
+	targetByUserAgent?: Record<string, MockResponseSpec>;
+	llmsByUserAgent?: Record<string, MockResponseSpec>;
+}
+
+function makeFetchMock(options: MockFetchOptions) {
+	return vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = input.toString();
+		const method = init?.method ?? "GET";
+		const userAgent = getUserAgent(init?.headers);
+
+		if (url === "https://example.com/robots.txt" && method === "GET") {
+			if (options.robots === null) {
+				return new Response("", { status: 404 });
+			}
+			return new Response(options.robots, { status: 200 });
+		}
+
+		if (url === "https://example.com/" && method === "HEAD") {
+			return responseFor(options.targetByUserAgent?.[userAgent] ?? options.defaultTarget);
+		}
+
+		if (url === "https://example.com/llms.txt" && method === "HEAD") {
+			return responseFor(options.llmsByUserAgent?.[userAgent] ?? options.defaultLlms);
+		}
+
+		return new Response("", { status: 404 });
+	});
+}
+
+function responseFor(spec: MockResponseSpec = { status: 200 }) {
+	return new Response("", {
+		status: spec.status,
+		headers: spec.headers,
+	});
+}
+
+function getUserAgent(headers: RequestInit["headers"]): string {
+	if (!headers) return "";
+	if (headers instanceof Headers) return headers.get("User-Agent") ?? "";
+	if (Array.isArray(headers)) {
+		const entry = headers.find(([key]) => key.toLowerCase() === "user-agent");
+		return entry?.[1] ?? "";
+	}
+	return (headers as Record<string, string>)["User-Agent"] ?? "";
+}
+
+function stripAnsi(str: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI stripping requires control chars
+	return str.replace(/\x1b\[[0-9;]*m/g, "");
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,320 @@
+import { AI_CRAWLERS, parseRobotsTxt } from "@aeorank/core";
+import chalk from "chalk";
+import { Command } from "commander";
+import { handleError } from "../errors.js";
+import { createSpinner } from "../ui/spinner.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const BLOCK_STATUSES = new Set([401, 403, 406, 407, 418, 429, 451, 503, 999]);
+const WAF_HEADERS = ["cf-mitigated", "x-amzn-waf-action"] as const;
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type RobotsAccess = "allowed" | "blocked" | "unspecified";
+export type VerdictStatus = "pass" | "warn" | "fail";
+
+export interface WafSignal {
+	header: (typeof WAF_HEADERS)[number];
+	value: string;
+}
+
+export interface DoctorHeadResult {
+	status: number | null;
+	blocked: boolean;
+	wafSignals: WafSignal[];
+	error?: string;
+}
+
+export interface CrawlerDoctorResult {
+	userAgent: string;
+	robots: RobotsAccess;
+	target: DoctorHeadResult;
+	llmsTxt: DoctorHeadResult;
+}
+
+export interface DoctorReport {
+	url: string;
+	robotsUrl: string;
+	llmsTxtUrl: string;
+	crawlers: CrawlerDoctorResult[];
+	verdict: {
+		status: VerdictStatus;
+		summary: string;
+	};
+}
+
+interface RunDoctorOptions {
+	fetchImpl?: FetchLike;
+	timeoutMs?: number;
+}
+
+export const doctorCommand = new Command("doctor")
+	.description("Diagnose AI crawler access, WAF blocks, and /llms.txt reachability")
+	.argument("<url>", "URL to diagnose")
+	.option("-f, --format <format>", "Output format (human or json)", "human")
+	.option("--timeout <ms>", "Per-request timeout in milliseconds", String(DEFAULT_TIMEOUT_MS))
+	.action(async (url: string, options: DoctorCommandOptions) => {
+		const isJson = options.format === "json";
+		const spinner = createSpinner(`Diagnosing ${url}...`, isJson);
+
+		try {
+			if (options.format !== "human" && options.format !== "json") {
+				throw new Error("Output format must be 'human' or 'json'.");
+			}
+
+			const timeoutMs = Number.parseInt(options.timeout, 10);
+			if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+				throw new Error("--timeout must be a positive number of milliseconds.");
+			}
+
+			spinner.start();
+			const report = await runDoctor(url, { timeoutMs });
+			spinner.stop();
+
+			if (isJson) {
+				console.log(JSON.stringify(report, null, 2));
+			} else {
+				console.log(renderDoctorReport(report));
+			}
+		} catch (error) {
+			spinner.stop();
+			const { message, suggestion } = handleError(error);
+
+			if (isJson) {
+				console.log(JSON.stringify({ error: message, suggestion }));
+			} else {
+				console.error(chalk.red(`Error: ${message}`));
+				console.error(suggestion);
+			}
+
+			process.exit(1);
+		}
+	});
+
+export async function runDoctor(
+	rawUrl: string,
+	options: RunDoctorOptions = {},
+): Promise<DoctorReport> {
+	const targetUrl = new URL(rawUrl);
+	targetUrl.hash = "";
+
+	const robotsUrl = new URL("/robots.txt", targetUrl);
+	const llmsTxtUrl = new URL("/llms.txt", targetUrl);
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	const robotsResponse = await fetchText(fetchImpl, robotsUrl, timeoutMs);
+	const robotsContent = robotsResponse.status === 200 ? robotsResponse.body : null;
+	const robotsInfo = parseRobotsTxt(targetUrl.toString(), robotsContent);
+
+	const crawlers = await Promise.all(
+		AI_CRAWLERS.map(async (crawler) => ({
+			userAgent: crawler,
+			robots: mapRobotsAccess(robotsInfo.crawlerAccess[crawler]),
+			target: await fetchHead(fetchImpl, targetUrl, crawler, timeoutMs),
+			llmsTxt: await fetchHead(fetchImpl, llmsTxtUrl, crawler, timeoutMs),
+		})),
+	);
+
+	return {
+		url: targetUrl.toString(),
+		robotsUrl: robotsUrl.toString(),
+		llmsTxtUrl: llmsTxtUrl.toString(),
+		crawlers,
+		verdict: buildVerdict(crawlers),
+	};
+}
+
+export function renderDoctorReport(report: DoctorReport): string {
+	const rows = [
+		["Crawler", "robots.txt", "Target HEAD", "/llms.txt HEAD", "WAF signal"],
+		...report.crawlers.map((crawler) => [
+			crawler.userAgent,
+			formatRobots(crawler.robots),
+			formatHead(crawler.target),
+			formatHead(crawler.llmsTxt),
+			formatWafSignals([...crawler.target.wafSignals, ...crawler.llmsTxt.wafSignals]),
+		]),
+	];
+
+	const verdictColor =
+		report.verdict.status === "pass"
+			? chalk.green
+			: report.verdict.status === "warn"
+				? chalk.yellow
+				: chalk.red;
+
+	return [
+		"",
+		chalk.bold(`AI crawler doctor: ${report.url}`),
+		chalk.dim(`robots.txt: ${report.robotsUrl}`),
+		chalk.dim(`llms.txt:   ${report.llmsTxtUrl}`),
+		"",
+		formatTable(rows),
+		"",
+		verdictColor.bold(
+			`Verdict: ${report.verdict.status.toUpperCase()} - ${report.verdict.summary}`,
+		),
+		"",
+	].join("\n");
+}
+
+async function fetchText(
+	fetchImpl: FetchLike,
+	url: URL,
+	timeoutMs: number,
+): Promise<{ status: number | null; body: string | null }> {
+	try {
+		const response = await fetchImpl(url, {
+			method: "GET",
+			headers: { "User-Agent": "AEOrank doctor (+https://aeorank.dev)" },
+			redirect: "follow",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+
+		return { status: response.status, body: await response.text() };
+	} catch {
+		return { status: null, body: null };
+	}
+}
+
+async function fetchHead(
+	fetchImpl: FetchLike,
+	url: URL,
+	userAgent: string,
+	timeoutMs: number,
+): Promise<DoctorHeadResult> {
+	try {
+		const response = await fetchImpl(url, {
+			method: "HEAD",
+			headers: {
+				"User-Agent": userAgent,
+				Accept: "text/plain, text/html, */*",
+			},
+			redirect: "follow",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		const wafSignals = collectWafSignals(response.headers);
+
+		return {
+			status: response.status,
+			blocked: isBlockedStatus(response.status) || wafSignals.length > 0,
+			wafSignals,
+		};
+	} catch (error) {
+		return {
+			status: null,
+			blocked: false,
+			wafSignals: [],
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function collectWafSignals(headers: Headers): WafSignal[] {
+	const signals: WafSignal[] = [];
+	for (const header of WAF_HEADERS) {
+		const value = headers.get(header);
+		if (value) {
+			signals.push({ header, value });
+		}
+	}
+	return signals;
+}
+
+function isBlockedStatus(status: number): boolean {
+	return BLOCK_STATUSES.has(status);
+}
+
+function mapRobotsAccess(value: "allowed" | "disallowed" | "unknown" | undefined): RobotsAccess {
+	if (value === "allowed") return "allowed";
+	if (value === "disallowed") return "blocked";
+	return "unspecified";
+}
+
+function buildVerdict(crawlers: CrawlerDoctorResult[]): DoctorReport["verdict"] {
+	const blockedCrawlers = crawlers.filter(
+		(crawler) => crawler.robots === "blocked" || crawler.target.blocked || crawler.llmsTxt.blocked,
+	).length;
+	const errors = crawlers.filter(
+		(crawler) => crawler.target.status === null || crawler.llmsTxt.status === null,
+	).length;
+	const unspecified = crawlers.filter((crawler) => crawler.robots === "unspecified").length;
+
+	if (blockedCrawlers > 0) {
+		return {
+			status: "fail",
+			summary: `${blockedCrawlers} crawler(s) look blocked.`,
+		};
+	}
+
+	if (errors > 0 || unspecified > 0) {
+		return {
+			status: "warn",
+			summary: "No explicit blocks found, but some checks were inconclusive.",
+		};
+	}
+
+	return {
+		status: "pass",
+		summary: "No AI crawler access blocks detected.",
+	};
+}
+
+function formatRobots(access: RobotsAccess): string {
+	if (access === "allowed") return chalk.green("allowed");
+	if (access === "blocked") return chalk.red("blocked");
+	return chalk.yellow("unspecified");
+}
+
+function formatHead(result: DoctorHeadResult): string {
+	if (result.status === null) {
+		return chalk.yellow(`error${result.error ? `: ${result.error}` : ""}`);
+	}
+	if (result.blocked) {
+		return chalk.red(`${result.status} blocked`);
+	}
+	if (result.status === 404) {
+		return chalk.dim("404 missing");
+	}
+	if (result.status === 405) {
+		return chalk.dim("405 no HEAD");
+	}
+	return chalk.green(`${result.status} reachable`);
+}
+
+function formatWafSignals(signals: WafSignal[]): string {
+	if (signals.length === 0) return "-";
+
+	const uniqueSignals = new Map<string, string>();
+	for (const signal of signals) {
+		uniqueSignals.set(signal.header, signal.value);
+	}
+
+	return [...uniqueSignals.entries()].map(([header, value]) => `${header}=${value}`).join(", ");
+}
+
+function formatTable(rows: string[][]): string {
+	const widths = rows[0].map((_, columnIndex) =>
+		Math.max(...rows.map((row) => stripAnsi(row[columnIndex]).length)),
+	);
+
+	return rows
+		.map((row, rowIndex) => {
+			const line = row
+				.map((cell, columnIndex) => cell + " ".repeat(widths[columnIndex] - stripAnsi(cell).length))
+				.join("  ");
+			return rowIndex === 0 ? chalk.bold(line) : line;
+		})
+		.join("\n");
+}
+
+function stripAnsi(value: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI stripping requires control chars
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+interface DoctorCommandOptions {
+	format: string;
+	timeout: string;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { compareCommand } from "./commands/compare.js";
+import { doctorCommand } from "./commands/doctor.js";
 import { initCommand } from "./commands/init.js";
 import { scanCommand } from "./commands/scan.js";
 
@@ -13,5 +14,6 @@ program
 program.addCommand(scanCommand);
 program.addCommand(initCommand);
 program.addCommand(compareCommand);
+program.addCommand(doctorCommand);
 
 program.parse(process.argv);


### PR DESCRIPTION
Summary
- add `aeorank doctor <url>` to report robots.txt access, target HEAD status, and `/llms.txt` HEAD status for each crawler in the core `AI_CRAWLERS` list
- flag common bot-mitigation signals from `cf-mitigated` and `x-amzn-waf-action`, plus access-control status codes, without treating 404 `/llms.txt` or 405 HEAD responses as blocks
- add human and JSON output, mocked fetch coverage, and a docs page/sidebar entry

Fixes #5.

Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @aeorank/core build`
- `pnpm exec biome check packages/cli/src/commands/doctor.ts packages/cli/src/__tests__/doctor.test.ts packages/cli/src/index.ts apps/docs/astro.config.mjs apps/docs/src/content/docs/cli/doctor.md`
- `pnpm --filter aeorank-cli exec vitest run src/__tests__/doctor.test.ts` -> 4 passed
- `pnpm --filter aeorank-cli test` -> 81 passed
- `pnpm --filter aeorank-cli build`
- `pnpm --filter @aeorank/docs build`
- `node packages/cli/dist/index.js doctor https://aeorank.dev --format json --timeout 8000` -> pass, blocked `[]`
- `node packages/cli/dist/index.js doctor https://vercel.com --format json --timeout 8000` -> pass, blocked `[]`
- `node packages/cli/dist/index.js doctor https://stripe.com --format json --timeout 8000` -> pass, blocked `[]`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

Notes
- I did not count `pnpm lint` as a clean gate because it currently reports pre-existing repo-wide formatting/generated `.astro` diagnostics and existing `packages/vitepress/src/plugin.ts` `any` diagnostics outside this diff.
- I did not count `pnpm --filter aeorank-cli typecheck` as a clean gate because it currently fails on existing CLI Node typing and definite-assignment issues in files such as `compare.ts` and `scan.ts`.
- AI-assisted contribution disclosure: I used OpenAI Codex to inspect the issue, make the focused code/test/docs changes, and run the checks above. I reviewed the resulting diff before submission.
