### PR TITLE
fix(web): resolve QStash callback origin so scans start indexing

### DIFF
--- a/.planning/workstreams/growth-distribution/STATE.md
+++ b/.planning/workstreams/growth-distribution/STATE.md
@@ -7,12 +7,12 @@ created: 2026-04-19
 
 ## Current Position
 **Status:** In progress
-**Current Phase:** Phase 02 complete — next: Phase 03 (README overhaul) before HN launch
+**Current Phase:** Phase 03 complete — next: Phase 06 (GitHub topics + awesome-list PRs), then Phase 04 (100-startup post) before HN
 **Last Activity:** 2026-04-28
-**Last Activity Description:** Phase 02 shipped via inline batch edit — docs site reconciled to 9 files, ai.txt added to enumerated lists, new ai-txt doc page
+**Last Activity Description:** Phase 03 shipped via full README overhaul + marketing site credibility fixes (placeholder citation URLs, unsourced stats softened)
 
 ## Progress
-**Phases Complete:** 2/16
+**Phases Complete:** 3/16
 **Current Plan:** N/A
 
 ## Phase Log
@@ -21,6 +21,15 @@ created: 2026-04-19
   - All 9 core generators wired with language-appropriate header (HTML comment for markdown/HTML/XML, `#` for text, `_generator` field for JSON)
   - 4 new tests pin the header (288 → 292 tests passing)
   - Commit: `747d958`
+- **2026-04-28 · Phase 03 · README overhaul** ✅
+  - Full README rewrite: added prominent star CTA below the demo GIF, "How it works" 3-step table, "Built for developers" positioning section, sharpened comparison table ("Telemetry: None" row added; "11 packages + 2 manual guides" replaces overstated "13")
+  - Pulled "Others monitor. AEOrank fixes." line from marketing Hero to align tone
+  - Softened unsourced stats ("40% of web discovery", "15.9% conversion") to qualitative claims — HN audience scrutinizes specific percentages without sources
+  - Auto-update markers preserved (`<!-- STATS_START -->` for readme-social-proof.yml workflow)
+  - Verified docs build still passes; marketing build still passes
+  - **Spillover credibility fixes (also committed):**
+    - `apps/marketing/src/components/Files.astro`: replaced `https://example.com/{report,conv}` placeholder citation URLs with self-referential demo content
+    - `apps/marketing/astro.config.mjs`: softened FAQ stat claim and corrected "13 framework plugins" overstatement
 - **2026-04-28 · Phase 02 · Reconcile 8 vs 9 files** ✅
   - 18 docs site references updated 8 → 9 across index, getting-started, what-is-aeo, cli/scan, dashboard/export, and 12 framework guides
   - New `apps/docs/src/content/docs/files/ai-txt.md` doc page with directives reference

--- a/.planning/workstreams/growth-distribution/STATE.md
+++ b/.planning/workstreams/growth-distribution/STATE.md
@@ -7,12 +7,12 @@ created: 2026-04-19
 
 ## Current Position
 **Status:** In progress
-**Current Phase:** Phase 01 complete — next: Phase 02 (reconcile 8 vs 9 files)
-**Last Activity:** 2026-04-19
-**Last Activity Description:** Phase 01 shipped via /gsd-fast — attribution header in all 9 generated files
+**Current Phase:** Phase 02 complete — next: Phase 03 (README overhaul) before HN launch
+**Last Activity:** 2026-04-28
+**Last Activity Description:** Phase 02 shipped via inline batch edit — docs site reconciled to 9 files, ai.txt added to enumerated lists, new ai-txt doc page
 
 ## Progress
-**Phases Complete:** 1/16
+**Phases Complete:** 2/16
 **Current Plan:** N/A
 
 ## Phase Log
@@ -21,6 +21,14 @@ created: 2026-04-19
   - All 9 core generators wired with language-appropriate header (HTML comment for markdown/HTML/XML, `#` for text, `_generator` field for JSON)
   - 4 new tests pin the header (288 → 292 tests passing)
   - Commit: `747d958`
+- **2026-04-28 · Phase 02 · Reconcile 8 vs 9 files** ✅
+  - 18 docs site references updated 8 → 9 across index, getting-started, what-is-aeo, cli/scan, dashboard/export, and 12 framework guides
+  - New `apps/docs/src/content/docs/files/ai-txt.md` doc page with directives reference
+  - `apps/docs/astro.config.mjs` sidebar entry for ai.txt under Generated Files
+  - `AEORANK_PROJECT.md` current-state description updated; `AEORANK_SPEC.md` and `AEORANK_ROADMAP.md` left as historical v1 artifacts (intentional scope cut)
+  - Verified: `astro build` produces 39 pages (up from 38)
+  - Commits: `5a380ad` (docs), pending (project doc)
+  - Note: GSD `/gsd-quick` blocked by SDK version mismatch (`@gsd-build/sdk@0.1.0` lacks `query` subcommand expected by workflow); fell back to inline batch edit for time pressure
 
 ## Session Continuity
 **Stopped At:** N/A

--- a/AEORANK_PROJECT.md
+++ b/AEORANK_PROJECT.md
@@ -9,7 +9,7 @@ Open-source CLI + SaaS that audits any website or GitHub repo for AI visibility,
 ## What it does
 - Scans any URL or local project directory
 - Scores AI readability across 12 dimensions (AEO Score 0–100)
-- Generates 8 files: llms.txt, llms-full.txt, CLAUDE.md, schema.json, robots-patch.txt, faq-blocks.html, citation-anchors.html, sitemap-ai.xml
+- Generates 9 files: llms.txt, llms-full.txt, CLAUDE.md, schema.json, robots-patch.txt, faq-blocks.html, citation-anchors.html, sitemap-ai.xml, ai.txt
 - Posts AEO score as a GitHub Check directly in PRs (via GitHub Actions, GITHUB_TOKEN)
 - Posts score comparison table as a PR comment (upsert, not spam)
 - Provides a web dashboard for ongoing monitoring

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <h3 align="center">Your site ranks #1 on Google — but is invisible to ChatGPT.</h3>
 
 <p align="center">
-  AEOrank scores your AI visibility 0–100 across <strong>36 criteria</strong>, then generates the <strong>9 files</strong> that get you cited by ChatGPT, Perplexity, Claude, and Google AI Overviews.
+  AEOrank scores your AI visibility 0–100 across <strong>36 deterministic checks</strong>, then generates the <strong>9 files</strong> that get you cited by ChatGPT, Perplexity, Claude, and Google AI Overviews.<br/>
+  <em>Others monitor. AEOrank fixes.</em>
 </p>
 
 <p align="center">
@@ -43,18 +44,30 @@ npx aeorank-cli scan https://your-site.com
 </p>
 
 <p align="center">
-  <em>30-second scan · 36 criteria · actionable fixes ranked by score impact</em>
+  <em>~30-second scan · 36 criteria · actionable fixes ranked by score impact</em>
 </p>
+
+> **⭐ If AEOrank saves you a $299/mo monitoring subscription, a star helps the next person find it.**
+
+## How it works
+
+| Step | What happens | Output |
+|------|--------------|--------|
+| **1. Scan** | Crawls up to 50 pages of your site, parses HTML/schema/llms.txt, and runs 36 deterministic checks across 5 pillars. | Per-dimension scores. |
+| **2. Score** | Aggregates into an AEO Score (0–100) with a letter grade and a ranked list of fixes by score impact. | `42/100 (D)` + recommendations. |
+| **3. Generate** | Writes 9 ready-to-deploy files (`llms.txt`, `schema.json`, `ai.txt`, …) tailored to your scan. | Drop into `public/`. Re-scan. |
+
+No account. No telemetry. No vendor dashboard to babysit.
 
 ## Why does this matter?
 
-AI search engines now drive **40% of web discovery**. ChatGPT converts visitors at **15.9%** — higher than Google organic. But traditional SEO tools don't check what AI engines actually look for.
+AI search engines route a meaningful and growing share of web discovery, and they read your site differently than Google does. Most sites are invisible to them by default — not because the content is bad, but because the structural signals (`llms.txt`, schema, FAQ markup, AI-crawler permissions) aren't there.
 
-AEOrank does.
+**Traditional SEO tools don't check what AI engines actually look for.** AEOrank does, and it generates the missing files for you.
 
-## AEOrank vs the competition
+## AEOrank vs the alternatives
 
-Every other AEO tool is paid SaaS targeting marketers. AEOrank is the **only open-source, developer-native** AEO tool.
+Every other AEO tool we found is closed-source SaaS targeting marketers. AEOrank is the only open-source, developer-native AEO toolkit.
 
 | | AEOrank | Scrunch | Adobe LLM Optimizer | Semrush AI |
 |---|:---:|:---:|:---:|:---:|
@@ -62,22 +75,31 @@ Every other AEO tool is paid SaaS targeting marketers. AEOrank is the **only ope
 | **Open source** | ✅ | ❌ | ❌ | ❌ |
 | **CLI** | ✅ | ❌ | ❌ | ❌ |
 | **GitHub integration** | ✅ Action + App | ❌ | ❌ | ❌ |
-| **Framework plugins** | **13** | 0 | 0 | 0 |
+| **Framework plugins** | **11 packages + 2 manual guides** | 0 | 0 | 0 |
 | **Generates AI files** | ✅ 9 files | ❌ | ❌ | ❌ |
-| **Scoring criteria** | 36 | Varies | Varies | Varies |
+| **Scoring criteria** | 36 deterministic | Varies | Varies | Varies |
 | **Self-hostable** | ✅ | ❌ | ❌ | ❌ |
+| **Telemetry** | None | Yes | Yes | Yes |
+
+> The category is "monitoring": dashboards that tell you ChatGPT didn't mention you. AEOrank fixes the upstream problem so AI engines *can* mention you.
 
 ## Three ways to use it
 
-### 1. CLI — scan any URL
+### 1. GitHub App — zero-config PR checks
+
+Install the [AEOrank GitHub App](https://github.com/apps/aeorank) on your repo. Every PR automatically gets an AEO Check Run. No YAML, no config, no secrets.
+
+### 2. CLI — scan any URL
 
 ```bash
 npx aeorank-cli scan https://your-site.com
 ```
 
-### 2. GitHub App — zero-config PR checks
+JSON output for scripting:
 
-Install the [AEOrank GitHub App](https://github.com/apps/aeorank) on your repo. Every PR automatically gets an AEO score as a Check Run — no YAML, no config.
+```bash
+npx aeorank-cli scan https://your-site.com --format json | jq '.score'
+```
 
 ### 3. GitHub Action — CI pipeline control
 
@@ -110,18 +132,20 @@ jobs:
 | ⚙️ **Technical Foundation** | 14% | Schema.org coverage, semantic HTML, image context, extraction friction, speakable markup |
 | 🔍 **AI Discovery** | 19% | llms.txt, AI crawler access, content licensing, canonical URLs, RSS feed, sitemap freshness |
 
+Full criteria reference: [docs.aeorank.dev/scoring/dimensions](https://docs.aeorank.dev/scoring/dimensions/)
+
 ## 9 generated files
 
-AEOrank generates all the files AI engines look for:
+AEOrank generates everything AI engines look for at your site root:
 
 | File | Purpose |
 |------|---------|
 | `llms.txt` | Site summary for LLM crawlers ([llmstxt.org](https://llmstxt.org) spec) |
 | `llms-full.txt` | Full-context version with Q&A pairs and entity disambiguation |
-| `ai.txt` | AI usage permissions and licensing |
+| `ai.txt` | AI usage permissions and licensing directives |
 | `CLAUDE.md` | Markdown context file for Claude |
-| `schema.json` | JSON-LD structured data |
-| `robots-patch.txt` | AI-specific robots.txt rules |
+| `schema.json` | JSON-LD structured data (Organization, WebSite, FAQ) |
+| `robots-patch.txt` | AI-crawler directives (GPTBot, ClaudeBot, PerplexityBot, Google-Extended) |
 | `faq-blocks.html` | FAQ with schema.org + speakable markup |
 | `citation-anchors.html` | Deep-linkable citation anchors |
 | `sitemap-ai.xml` | AI-optimized sitemap |
@@ -160,6 +184,8 @@ export default withAeorank({
 // → All 9 AEO files now served at your site root
 ```
 
+Webflow and Squarespace have manual setup guides: [docs.aeorank.dev/frameworks](https://docs.aeorank.dev/frameworks/).
+
 ## SaaS Dashboard
 
 Track your AEO score over time at [app.aeorank.dev](https://app.aeorank.dev):
@@ -168,6 +194,7 @@ Track your AEO score over time at [app.aeorank.dev](https://app.aeorank.dev):
 - 30-day score history with sparkline charts
 - Download all 9 generated files as a ZIP
 - Free tier: 1 site, 3 scans/month
+- Self-host the entire stack — code is MIT-licensed
 
 ## Packages
 
@@ -186,11 +213,17 @@ Track your AEO score over time at [app.aeorank.dev](https://app.aeorank.dev):
 | [`@aeorank/vitepress`](https://www.npmjs.com/package/@aeorank/vitepress) | VitePress plugin |
 | [`@aeorank/docusaurus`](https://www.npmjs.com/package/@aeorank/docusaurus) | Docusaurus plugin |
 
+## Built for developers
+
+- **MIT licensed.** Every package, every plugin, every file generator. Fork it.
+- **Self-hostable end-to-end.** CLI, scoring engine, GitHub App, GitHub Action, web dashboard — all open source. Stand the entire stack up inside your own infra.
+- **No telemetry.** The CLI does not phone home. The scan runs locally.
+- **Deterministic scoring.** Same input → same score. Same scan re-run → same files. No model calls in the scoring path, so results are reproducible across machines and over time.
+- **Drop-in framework plugins.** One config line, files served at the right routes on build. No vendor dashboard required.
+
 ## Live Demo
 
 See [DEMO.md](./DEMO.md) for today's auto-generated scan.
-
-Last updated: April 25, 2026
 
 ## Star History
 
@@ -215,7 +248,7 @@ We ship fast and merge fast. New framework plugins, new scoring criteria, and re
 git clone https://github.com/vinpatel/aeorank.git
 cd aeorank
 pnpm install
-pnpm test    # 675 tests across 13 packages
+pnpm test
 ```
 
 ## Share
@@ -230,4 +263,3 @@ If AEOrank saved you a $299/mo subscription, the best thank-you is sending it to
 ## License
 
 [MIT](LICENSE) — built by [Vin Patel](https://github.com/vinpatel), sponsored by [Linx Agency](https://linx.agency) & [Mindtrades](https://mindtrades.com).
-

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
 							slug: "files/citation-anchors-html",
 						},
 						{ label: "sitemap-ai.xml", slug: "files/sitemap-ai-xml" },
+						{ label: "ai.txt", slug: "files/ai-txt" },
 					],
 				},
 				{

--- a/apps/docs/src/content/docs/cli/scan.md
+++ b/apps/docs/src/content/docs/cli/scan.md
@@ -1,9 +1,9 @@
 ---
 title: "aeorank scan"
-description: Scan a URL and generate an AEO score with all 8 files.
+description: Scan a URL and generate an AEO score with all 9 files.
 ---
 
-Scan a website URL and generate an AEO score with dimension breakdown and all 8 output files.
+Scan a website URL and generate an AEO score with dimension breakdown and all 9 output files.
 
 ## Usage
 

--- a/apps/docs/src/content/docs/dashboard/export.md
+++ b/apps/docs/src/content/docs/dashboard/export.md
@@ -7,7 +7,7 @@ AEOrank provides two export options from the dashboard.
 
 ## Download files (ZIP)
 
-Click **Download all files (ZIP)** to get all 8 generated files for your site in a single archive. These are ready to deploy to your site.
+Click **Download all files (ZIP)** to get all 9 generated files for your site in a single archive. These are ready to deploy to your site.
 
 ## Export report
 

--- a/apps/docs/src/content/docs/files/ai-txt.md
+++ b/apps/docs/src/content/docs/files/ai-txt.md
@@ -1,0 +1,61 @@
+---
+title: ai.txt
+description: Machine-readable AI content licensing directives — declare how AI engines can train on, summarize, and cite your content.
+---
+
+The `ai.txt` file is a machine-readable declaration of how AI systems are permitted to use your content for training, inference, summarization, and attribution.
+
+## What it is
+
+A plain-text manifest at your site root that AI crawlers and inference systems can fetch to understand your licensing terms. It complements `robots.txt` (which controls *access*) by specifying *usage rights* once the content has been read.
+
+## Why it matters
+
+`robots.txt` answers "can you crawl this?" `ai.txt` answers "what can you do with what you crawled?" As AI training and inference become regulated, having an explicit, parseable licensing statement at a known location reduces ambiguity for crawler operators and gives you a defensible record of your stated terms.
+
+## Directives
+
+| Directive | Values | Purpose |
+|-----------|--------|---------|
+| `User-Agent` | `*` or specific bot | Which AI systems the rules apply to |
+| `Allow-AI-Training` | `Yes` / `No` | May this content be used to train models? |
+| `Allow-AI-Inference` | `Yes` / `No` | May this content be retrieved at inference time? |
+| `Allow-AI-Summarization` | `Yes` / `No` | May this content be summarized in AI answers? |
+| `Allow-AI-Attribution` | `Required` / `Optional` | Must AI systems cite the source? |
+| `License` | SPDX identifier | The content license (e.g., `CC-BY-4.0`) |
+| `Attribution` | Free text | How you want to be credited |
+| `Contact` | URL or text | Where to direct licensing questions |
+
+## Example output
+
+```
+# ai.txt - AI Content Licensing
+#
+# Site: Example
+# URL: https://example.com
+
+User-Agent: *
+Allow-AI-Training: Yes
+Allow-AI-Inference: Yes
+Allow-AI-Summarization: Yes
+Allow-AI-Attribution: Required
+
+# Content License
+License: CC-BY-4.0
+Attribution: Example (https://example.com)
+Contact: See https://example.com for contact information
+```
+
+## How to deploy
+
+Place `ai.txt` at the root of your site, alongside `robots.txt`:
+
+```
+https://your-site.com/ai.txt
+```
+
+If your site already has an `ai.txt`, AEOrank's generated file is a recommended template — review and merge with your existing terms before replacing.
+
+:::caution
+`ai.txt` is an emerging convention, not a binding standard. Compliant crawlers respect it; non-compliant ones will not. Treat it as a clear public statement of your terms, not a technical access control.
+:::

--- a/apps/docs/src/content/docs/frameworks/11ty.md
+++ b/apps/docs/src/content/docs/frameworks/11ty.md
@@ -31,8 +31,8 @@ module.exports = function (eleventyConfig) {
 };
 ```
 
-The plugin hooks into the `eleventy.after` event and writes all 8 AEO files to your output directory after each build.
+The plugin hooks into the `eleventy.after` event and writes all 9 AEO files to your output directory after each build.
 
 ## Generated Files
 
-After `eleventy`, all 8 AEO files are in `_site/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`.
+After `eleventy`, all 9 AEO files are in `_site/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`, `ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/astro.md
+++ b/apps/docs/src/content/docs/frameworks/astro.md
@@ -36,8 +36,8 @@ export default defineConfig({
 
 That's it. The integration:
 - **Dev**: Serves AEO files via Vite middleware at `localhost:4321/llms.txt`, etc.
-- **Build**: Writes all 8 files to your output directory.
+- **Build**: Writes all 9 files to your output directory.
 
 ## Generated Files
 
-All 8 AEO files are available at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are available at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/docusaurus.md
+++ b/apps/docs/src/content/docs/frameworks/docusaurus.md
@@ -34,8 +34,8 @@ const config = {
 };
 ```
 
-The plugin uses Docusaurus's `postBuild` hook to write all 8 AEO files to the build output directory.
+The plugin uses Docusaurus's `postBuild` hook to write all 9 AEO files to the build output directory.
 
 ## Generated Files
 
-After `docusaurus build`, all 8 AEO files are in `build/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`.
+After `docusaurus build`, all 9 AEO files are in `build/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`, `ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/gatsby.md
+++ b/apps/docs/src/content/docs/frameworks/gatsby.md
@@ -38,8 +38,8 @@ const config: GatsbyConfig = {
 export default config;
 ```
 
-The plugin hooks into Gatsby's `onPostBuild` lifecycle and writes all 8 AEO files to the `public/` directory.
+The plugin hooks into Gatsby's `onPostBuild` lifecycle and writes all 9 AEO files to the `public/` directory.
 
 ## Generated Files
 
-After `gatsby build`, all 8 AEO files are in `public/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`.
+After `gatsby build`, all 9 AEO files are in `public/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`, `ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/next.md
+++ b/apps/docs/src/content/docs/frameworks/next.md
@@ -89,4 +89,4 @@ export default aeorank({
 
 ## Generated Files
 
-All 8 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/nuxt.md
+++ b/apps/docs/src/content/docs/frameworks/nuxt.md
@@ -30,10 +30,10 @@ export default defineNuxtConfig({
 });
 ```
 
-The module registers Nitro server routes for all 8 AEO files. They're available in both dev and production.
+The module registers Nitro server routes for all 9 AEO files. They're available in both dev and production.
 
 ## Generated Files
 
-All 8 AEO files are served as Nitro routes: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served as Nitro routes: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.
 
 Each route returns the correct `Content-Type` header and is cached with `Cache-Control: public, max-age=3600, s-maxage=86400`.

--- a/apps/docs/src/content/docs/frameworks/remix.md
+++ b/apps/docs/src/content/docs/frameworks/remix.md
@@ -47,13 +47,14 @@ import { aeoConfig } from "~/aeo.config";
 export const loader = createAeoLoader("llms-full.txt", aeoConfig);
 ```
 
-Repeat the same pattern for all 8 files:
+Repeat the same pattern for all 9 files:
 - `app/routes/CLAUDE[.]md.ts`
 - `app/routes/schema[.]json.ts`
 - `app/routes/robots-patch[.]txt.ts`
 - `app/routes/faq-blocks[.]html.ts`
 - `app/routes/citation-anchors[.]html.ts`
 - `app/routes/sitemap-ai[.]xml.ts`
+- `app/routes/ai[.]txt.ts`
 
 ## Static Generation
 
@@ -68,4 +69,4 @@ generateAeoFiles(aeoConfig);
 
 ## Generated Files
 
-All 8 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/shopify.md
+++ b/apps/docs/src/content/docs/frameworks/shopify.md
@@ -41,7 +41,7 @@ import { aeoConfig } from "~/aeo.config";
 export const loader = createAeoLoader("llms.txt", aeoConfig);
 ```
 
-Repeat for all 8 files:
+Repeat for all 9 files:
 - `app/routes/llms-full[.]txt.tsx`
 - `app/routes/CLAUDE[.]md.tsx`
 - `app/routes/schema[.]json.tsx`
@@ -49,7 +49,8 @@ Repeat for all 8 files:
 - `app/routes/faq-blocks[.]html.tsx`
 - `app/routes/citation-anchors[.]html.tsx`
 - `app/routes/sitemap-ai[.]xml.tsx`
+- `app/routes/ai[.]txt.tsx`
 
 ## Generated Files
 
-All 8 AEO files are served at your store root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served at your store root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/sveltekit.md
+++ b/apps/docs/src/content/docs/frameworks/sveltekit.md
@@ -47,13 +47,14 @@ import { aeoConfig } from "$lib/aeo.config";
 export const GET = createAeoHandler("llms-full.txt", aeoConfig);
 ```
 
-Repeat for all 8 files:
+Repeat for all 9 files:
 - `src/routes/CLAUDE.md/+server.ts`
 - `src/routes/schema.json/+server.ts`
 - `src/routes/robots-patch.txt/+server.ts`
 - `src/routes/faq-blocks.html/+server.ts`
 - `src/routes/citation-anchors.html/+server.ts`
 - `src/routes/sitemap-ai.xml/+server.ts`
+- `src/routes/ai.txt/+server.ts`
 
 ## Static Generation
 
@@ -68,4 +69,4 @@ generateAeoFiles({ ...aeoConfig, outputDir: "static" });
 
 ## Generated Files
 
-All 8 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/vitepress.md
+++ b/apps/docs/src/content/docs/frameworks/vitepress.md
@@ -40,4 +40,4 @@ In dev mode, AEO files are served via middleware. During build, files are writte
 
 ## Generated Files
 
-After `vitepress build`, all 8 AEO files are in `.vitepress/dist/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`.
+After `vitepress build`, all 9 AEO files are in `.vitepress/dist/`: `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `schema.json`, `robots-patch.txt`, `faq-blocks.html`, `citation-anchors.html`, `sitemap-ai.xml`, `ai.txt`.

--- a/apps/docs/src/content/docs/frameworks/webflow.md
+++ b/apps/docs/src/content/docs/frameworks/webflow.md
@@ -13,7 +13,7 @@ Use the CLI to scan your site and generate AEO files:
 npx aeorank-cli scan https://your-site.webflow.io
 ```
 
-This writes 8 files to `./aeo-output/`.
+This writes 9 files to `./aeo-output/`.
 
 ## Step 2: Host the files
 
@@ -27,7 +27,7 @@ Create a Cloudflare Worker that serves your AEO files at your domain:
 const files = {
   "/llms.txt": { content: "...", type: "text/plain" },
   "/schema.json": { content: "...", type: "application/ld+json" },
-  // ... add all 8 files
+  // ... add all 9 files
 };
 
 export default {

--- a/apps/docs/src/content/docs/frameworks/wordpress.md
+++ b/apps/docs/src/content/docs/frameworks/wordpress.md
@@ -28,4 +28,4 @@ No static files are written to disk. Responses are cached with `Cache-Control: p
 
 ## Generated Files
 
-All 8 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`.
+All 9 AEO files are served at your site root: `/llms.txt`, `/llms-full.txt`, `/CLAUDE.md`, `/schema.json`, `/robots-patch.txt`, `/faq-blocks.html`, `/citation-anchors.html`, `/sitemap-ai.xml`, `/ai.txt`.

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -28,7 +28,7 @@ You'll see output like this:
 Scanning https://your-site.com...
 ✓ Fetched 12 pages in 3.2s
 ✓ Analyzed structure and schema
-✓ Generated 8 files
+✓ Generated 9 files
 
 AEO Score: 42/100 (D)
 
@@ -47,14 +47,14 @@ HTTPS & Redirects      100    ✓ pass
 Page Freshness          50    ⚠ warn
 Citation Anchors        10    ✗ fail
 
-→ 8 files written to ./aeo-output/
+→ 9 files written to ./aeo-output/
 ```
 
 Each criterion is scored 0-10 and weighted by percentage importance. See [36 Criteria](/scoring/dimensions/) for details on what each one measures.
 
 ## Step 3: Check your generated files
 
-AEOrank writes 8 files to `./aeo-output/` by default:
+AEOrank writes 9 files to `./aeo-output/` by default:
 
 | File | What it does |
 |------|-------------|
@@ -66,6 +66,7 @@ AEOrank writes 8 files to `./aeo-output/` by default:
 | `faq-blocks.html` | Speakable FAQ schema markup |
 | `citation-anchors.html` | Heading anchors for AI citations |
 | `sitemap-ai.xml` | AI-optimized sitemap |
+| `ai.txt` | Machine-readable AI content licensing directives |
 
 See [Generated Files](/files/llms-txt/) for detailed documentation on each file.
 
@@ -78,6 +79,7 @@ Copy the generated files to your website:
 3. **robots-patch.txt** → append the directives to your existing robots.txt
 4. **faq-blocks.html** and **citation-anchors.html** → add to relevant pages
 5. **sitemap-ai.xml** → root of your site, reference in robots.txt
+6. **ai.txt** → root of your site (next to robots.txt) — declares AI training and attribution terms
 
 Run the scan again after deploying to see your score improve.
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: AEOrank Documentation
 description: Learn how to scan your site, understand your AEO score, and deploy the generated files that make your content visible to AI engines.
 template: splash
 hero:
-  tagline: Scan your site, get an AEO score, and generate the 8 files AI engines look for.
+  tagline: Scan your site, get an AEO score, and generate the 9 files AI engines look for.
   image:
     html: '<svg width="160" height="160" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="32" height="32" rx="7" fill="#E8590C" /><path d="M8 22L13.5 10H18.5L24 22" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M10.5 18H21.5" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/></svg>'
   actions:
@@ -22,7 +22,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <Card title="Quick Start" icon="rocket">
-    Run `npx aeorank-cli scan https://your-site.com` to get your AEO score and generate all 8 files.
+    Run `npx aeorank-cli scan https://your-site.com` to get your AEO score and generate all 9 files.
     [Read the guide &rarr;](/getting-started/)
   </Card>
   <Card title="What is AEO?" icon="information">
@@ -41,7 +41,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## Framework guides
 
-Drop-in plugins for your stack. One config change, 8 AEO files, zero maintenance.
+Drop-in plugins for your stack. One config change, 9 AEO files, zero maintenance.
 
 <CardGrid>
   <LinkCard title="Next.js" href="/frameworks/next/" />
@@ -61,7 +61,7 @@ Drop-in plugins for your stack. One config change, 8 AEO files, zero maintenance
 
 ## Generated files
 
-AEOrank generates 8 files that AI engines look for at your site root.
+AEOrank generates 9 files that AI engines look for at your site root.
 
 <CardGrid>
   <LinkCard title="llms.txt" description="Summary of your site for LLM crawlers" href="/files/llms-txt/" />
@@ -72,4 +72,5 @@ AEOrank generates 8 files that AI engines look for at your site root.
   <LinkCard title="faq-blocks.html" description="FAQ with schema.org markup" href="/files/faq-blocks-html/" />
   <LinkCard title="citation-anchors.html" description="Citation anchor elements" href="/files/citation-anchors-html/" />
   <LinkCard title="sitemap-ai.xml" description="AI-optimized sitemap" href="/files/sitemap-ai-xml/" />
+  <LinkCard title="ai.txt" description="AI content licensing directives" href="/files/ai-txt/" />
 </CardGrid>

--- a/apps/docs/src/content/docs/what-is-aeo.md
+++ b/apps/docs/src/content/docs/what-is-aeo.md
@@ -26,7 +26,7 @@ AEO complements SEO — you should do both.
 
 ## What AEOrank does
 
-AEOrank measures your site's AI visibility across [36 criteria across 5 pillars](/scoring/dimensions/) and generates 8 files that AI engines look for:
+AEOrank measures your site's AI visibility across [36 criteria across 5 pillars](/scoring/dimensions/) and generates 9 files that AI engines look for:
 
 1. **Scans** your site (up to 50 pages, under 30 seconds)
 2. **Scores** your AI visibility from 0-100
@@ -34,7 +34,7 @@ AEOrank measures your site's AI visibility across [36 criteria across 5 pillars]
 
 The CLI is free, open source, and MIT-licensed. No account required.
 
-## The 8 generated files
+## The 9 generated files
 
 AEOrank produces these files tailored to your specific site:
 
@@ -46,5 +46,6 @@ AEOrank produces these files tailored to your specific site:
 - **faq-blocks.html** — speakable FAQ schema markup
 - **citation-anchors.html** — heading anchors that make content citable
 - **sitemap-ai.xml** — AI-optimized sitemap with content hints
+- **ai.txt** — machine-readable AI content licensing and attribution directives
 
 Deploy these files on your site and AI engines will have everything they need to understand and cite your content.

--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig({
 				},
 				{
 					question: "What is AEO and why should I care?",
-					answer: "Answer Engine Optimization. AI search engines like ChatGPT, Perplexity, Claude, and Gemini now drive 40% of web discovery and convert visitors at 15.9% — higher than Google organic. AEO is how you get into those AI-generated answers. If you're not optimized for AI extraction, your competitors are getting cited instead of you."
+					answer: "Answer Engine Optimization. AI search engines like ChatGPT, Perplexity, Claude, and Gemini are taking a fast-growing share of web discovery, and the visitors they send tend to convert at higher rates than typical organic search. AEO is how you get into those AI-generated answers. If you're not optimized for AI extraction, your competitors are getting cited instead of you."
 				},
 				{
 					question: "How is AEOrank different from SEO tools like Ahrefs or Semrush?",
@@ -40,7 +40,7 @@ export default defineConfig({
 				},
 				{
 					question: "Is it really free? What's the catch?",
-					answer: "The CLI, GitHub App, GitHub Action, and all 13 framework plugins are MIT licensed and always free. The Starter plan gives you 1 site and 3 scans per month at no cost. Pro ($29/mo) adds 5 sites, 50 scans, score history, auto-rescan, and PDF exports. Agency ($99/mo) scales to 50 sites with API access. Every plan includes full 36-criteria scoring and all 9 generated files — we don't gate the features that matter."
+					answer: "The CLI, GitHub App, GitHub Action, and every framework plugin are MIT licensed and always free. The Starter plan gives you 1 site and 3 scans per month at no cost. Pro ($29/mo) adds 5 sites, 50 scans, score history, auto-rescan, and PDF exports. Agency ($99/mo) scales to 50 sites with API access. Every plan includes full 36-criteria scoring and all 9 generated files — we don't gate the features that matter."
 				},
 				{
 					question: "What AI engines does AEOrank optimize for?",

--- a/apps/marketing/src/components/Files.astro
+++ b/apps/marketing/src/components/Files.astro
@@ -144,8 +144,8 @@ Contact: hello@your-site.com
 		lang: "json",
 		content: `{
   "citations": [
-    { "n": 1, "claim": "40% of discovery is now AI", "src": "https://example.com/report" },
-    { "n": 2, "claim": "AI traffic converts at 15.9%", "src": "https://example.com/conv"  }
+    { "n": 1, "claim": "AEOrank scores AI visibility 0–100",     "src": "https://aeorank.dev/scoring" },
+    { "n": 2, "claim": "9 files generated per scan, MIT licensed", "src": "https://docs.aeorank.dev/files/llms-txt" }
   ]
 }`,
 	},

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -18,6 +18,12 @@ SUPABASE_SERVICE_ROLE_KEY=eyJ...
 # App URL (used for QStash callbacks, Stripe return URLs)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Vercel Cron — used to authenticate /api/cron/rescan requests.
+# Generate any random string. Vercel Cron auto-injects this as
+# `Authorization: Bearer $CRON_SECRET` when the env var is set on the project.
+# If unset, scheduled rescans never run.
+CRON_SECRET=
+
 # QStash (Upstash) — for async scan job queue
 # Get from: https://console.upstash.com/qstash
 QSTASH_TOKEN=

--- a/apps/web/app/api/cron/rescan/route.test.ts
+++ b/apps/web/app/api/cron/rescan/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Hoisted mocks — vitest requires factory closure here, no top-level vars.
+const { supabaseChain, publishJSON } = vi.hoisted(() => ({
+	supabaseChain: { result: { data: [] as unknown[] | null, error: null as unknown } },
+	publishJSON: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+	captureMessage: vi.fn(),
+	captureException: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => {
+	function makeQuery(): unknown {
+		const q: Record<string, unknown> = {};
+		const passthrough = () => q;
+		q.select = passthrough;
+		q.eq = passthrough;
+		q.not = passthrough;
+		q.lte = passthrough;
+		q.update = passthrough;
+		q.insert = () => ({
+			select: () => ({
+				single: async () => ({ data: { id: "scan-1" }, error: null }),
+			}),
+		});
+		q.then = (resolve: (v: unknown) => unknown) => Promise.resolve(supabaseChain.result).then(resolve);
+		return q;
+	}
+	return {
+		createServiceSupabaseClient: () => ({ from: () => makeQuery() }),
+	};
+});
+
+vi.mock("@/lib/qstash", () => ({
+	getQStashClient: () => ({ publishJSON }),
+}));
+
+async function callGet(req: Request) {
+	const mod = await import("./route");
+	return mod.GET(req);
+}
+
+describe("GET /api/cron/rescan", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		supabaseChain.result = { data: [], error: null };
+		publishJSON.mockReset();
+	});
+
+	afterEach(() => {
+		delete process.env.CRON_SECRET;
+	});
+
+	it("returns 500 when CRON_SECRET is not configured", async () => {
+		const res = await callGet(new Request("http://x/api/cron/rescan"));
+		expect(res.status).toBe(500);
+	});
+
+	it("returns 401 when authorization header does not match", async () => {
+		process.env.CRON_SECRET = "expected-secret";
+		const res = await callGet(
+			new Request("http://x/api/cron/rescan", {
+				headers: { authorization: "Bearer wrong-secret" },
+			}),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns enqueued:0 when no sites are due", async () => {
+		process.env.CRON_SECRET = "expected-secret";
+		supabaseChain.result = { data: [], error: null };
+		const res = await callGet(
+			new Request("http://x/api/cron/rescan", {
+				headers: { authorization: "Bearer expected-secret" },
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ enqueued: 0 });
+		expect(publishJSON).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 when the supabase query errors", async () => {
+		process.env.CRON_SECRET = "expected-secret";
+		supabaseChain.result = { data: null, error: { message: "boom" } };
+		const res = await callGet(
+			new Request("http://x/api/cron/rescan", {
+				headers: { authorization: "Bearer expected-secret" },
+			}),
+		);
+		expect(res.status).toBe(500);
+	});
+});

--- a/apps/web/app/api/cron/rescan/route.ts
+++ b/apps/web/app/api/cron/rescan/route.ts
@@ -1,6 +1,8 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import { createServiceSupabaseClient } from "@/lib/supabase";
 import { getQStashClient } from "@/lib/qstash";
+import { resolveAppUrl } from "@/lib/app-url";
 
 const SCHEDULE_INTERVALS: Record<string, number> = {
 	daily: 24 * 60 * 60 * 1000,
@@ -13,9 +15,14 @@ const SCHEDULE_INTERVALS: Record<string, number> = {
  * Finds sites due for rescan and enqueues them via QStash.
  */
 export async function GET(request: Request) {
-	// Verify cron secret to prevent unauthorized triggers
+	const expected = process.env.CRON_SECRET;
+	if (!expected) {
+		console.error("CRON_SECRET is not configured — refusing to run");
+		Sentry.captureMessage("CRON_SECRET missing in cron/rescan", { level: "error" });
+		return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+	}
 	const authHeader = request.headers.get("authorization");
-	if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+	if (authHeader !== `Bearer ${expected}`) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 	}
 
@@ -28,12 +35,30 @@ export async function GET(request: Request) {
 		.not("rescan_schedule", "is", null)
 		.lte("next_rescan_at", new Date().toISOString());
 
-	if (error || !sites || sites.length === 0) {
+	if (error) {
+		console.error("cron/rescan: query failed", error);
+		Sentry.captureException(error, { tags: { source: "cron-rescan-query" } });
+		return NextResponse.json({ error: "query_failed" }, { status: 500 });
+	}
+
+	if (!sites || sites.length === 0) {
 		return NextResponse.json({ enqueued: 0 });
 	}
 
 	const qstash = getQStashClient();
 	let enqueued = 0;
+
+	// Resolve the callback origin once. If it can only resolve to an
+	// unreachable (localhost) origin, publishing would silently strand every
+	// rescan at "pending" — fail the whole run loudly instead.
+	let callbackBase: string;
+	try {
+		callbackBase = resolveAppUrl(request);
+	} catch (err) {
+		console.error("cron/rescan: cannot resolve app URL for callback", err);
+		Sentry.captureException(err, { tags: { source: "cron-rescan-app-url" } });
+		return NextResponse.json({ error: "app_url_unresolved" }, { status: 500 });
+	}
 
 	for (const site of sites) {
 		// Insert pending scan
@@ -43,16 +68,24 @@ export async function GET(request: Request) {
 			.select("id")
 			.single();
 
-		if (scanError || !scanRecord) continue;
+		if (scanError || !scanRecord) {
+			console.error("cron/rescan: failed to insert scan row", { siteId: site.id, scanError });
+			Sentry.captureException(scanError ?? new Error("scan insert returned no row"), {
+				tags: { source: "cron-rescan-insert" },
+			});
+			continue;
+		}
 
 		// Enqueue via QStash
 		try {
 			await qstash.publishJSON({
-				url: `${process.env.NEXT_PUBLIC_APP_URL}/api/scan/process`,
+				url: `${callbackBase}/api/scan/process`,
 				body: { scanId: scanRecord.id, url: site.url },
 			});
 			enqueued++;
-		} catch {
+		} catch (err) {
+			console.error("cron/rescan: QStash publish failed", { siteId: site.id, err });
+			Sentry.captureException(err, { tags: { source: "cron-rescan-qstash" } });
 			await supabase
 				.from("scans")
 				.update({ status: "error", error: "Failed to enqueue rescan" })

--- a/apps/web/app/api/scan/route.ts
+++ b/apps/web/app/api/scan/route.ts
@@ -4,6 +4,7 @@ import { createServerSupabaseClient } from "@/lib/supabase";
 import { createServiceSupabaseClient } from "@/lib/supabase";
 import { validateScanUrl } from "@/lib/validate-url";
 import { getQStashClient } from "@/lib/qstash";
+import { resolveAppUrl } from "@/lib/app-url";
 import { getCurrentPlan, canAddSite, canRunScan } from "@/lib/plan";
 
 export async function POST(request: Request) {
@@ -107,7 +108,7 @@ export async function POST(request: Request) {
 	try {
 		const qstash = getQStashClient();
 		await qstash.publishJSON({
-			url: `${process.env.NEXT_PUBLIC_APP_URL}/api/scan/process`,
+			url: `${resolveAppUrl(request)}/api/scan/process`,
 			body: { scanId: scanRecord.id, url: validatedUrl },
 		});
 	} catch (err) {

--- a/apps/web/app/api/sites/[siteId]/schedule/route.ts
+++ b/apps/web/app/api/sites/[siteId]/schedule/route.ts
@@ -4,10 +4,12 @@ import { createServerSupabaseClient } from "@/lib/supabase";
 
 const VALID_SCHEDULES = ["daily", "weekly", "monthly", null];
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 const SCHEDULE_INTERVALS: Record<string, number> = {
-	daily: 24 * 60 * 60 * 1000,
-	weekly: 7 * 24 * 60 * 60 * 1000,
-	monthly: 30 * 24 * 60 * 60 * 1000,
+	daily: DAY_MS,
+	weekly: 7 * DAY_MS,
+	monthly: 30 * DAY_MS,
 };
 
 interface RouteParams {
@@ -35,8 +37,13 @@ export async function PUT(request: Request, { params }: RouteParams) {
 
 	const supabase = createServerSupabaseClient();
 
+	// Subtract one cron period (24h) so the very next 6am UTC tick after
+	// roughly `interval` has elapsed picks this site up. Without this offset,
+	// "daily" lags ~44h, "weekly" lags ~7d 20h on the first run.
 	const nextRescan = body.schedule
-		? new Date(Date.now() + (SCHEDULE_INTERVALS[body.schedule] ?? SCHEDULE_INTERVALS.weekly)).toISOString()
+		? new Date(
+			Date.now() + (SCHEDULE_INTERVALS[body.schedule] ?? SCHEDULE_INTERVALS.weekly) - DAY_MS,
+		).toISOString()
 		: null;
 
 	const { error } = await supabase

--- a/apps/web/lib/app-url.test.ts
+++ b/apps/web/lib/app-url.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isLocalhostOrigin, resolveAppUrl } from "./app-url";
+
+function req(headers: Record<string, string> = {}): Request {
+	return new Request("http://internal/api/scan", { headers });
+}
+
+const ENV_KEYS = [
+	"NEXT_PUBLIC_APP_URL",
+	"VERCEL_ENV",
+	"VERCEL",
+	"VERCEL_URL",
+	"VERCEL_PROJECT_PRODUCTION_URL",
+] as const;
+
+describe("isLocalhostOrigin", () => {
+	it("detects localhost forms", () => {
+		for (const v of [
+			"http://localhost:3000",
+			"localhost",
+			"127.0.0.1",
+			"http://127.0.0.1:3000",
+			"0.0.0.0",
+			"app.localhost",
+		]) {
+			expect(isLocalhostOrigin(v)).toBe(true);
+		}
+	});
+
+	it("passes real hosts", () => {
+		for (const v of ["https://aeorank.dev", "aeorank.dev", "app.aeorank.dev"]) {
+			expect(isLocalhostOrigin(v)).toBe(false);
+		}
+	});
+});
+
+describe("resolveAppUrl", () => {
+	beforeEach(() => {
+		for (const k of ENV_KEYS) delete process.env[k];
+	});
+	afterEach(() => {
+		for (const k of ENV_KEYS) delete process.env[k];
+	});
+
+	it("uses NEXT_PUBLIC_APP_URL when set (non-deployed) and strips trailing slash", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "https://aeorank.dev/";
+		expect(resolveAppUrl(req())).toBe("https://aeorank.dev");
+	});
+
+	it("returns configured localhost when not deployed (local dev)", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+		expect(resolveAppUrl(req())).toBe("http://localhost:3000");
+	});
+
+	it("ignores a localhost NEXT_PUBLIC_APP_URL when deployed and derives from request", () => {
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+		process.env.VERCEL_ENV = "production";
+		const url = resolveAppUrl(
+			req({ "x-forwarded-host": "aeorank.dev", "x-forwarded-proto": "https" }),
+		);
+		expect(url).toBe("https://aeorank.dev");
+	});
+
+	it("prefers x-forwarded-host over host header", () => {
+		process.env.VERCEL_ENV = "production";
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+		const url = resolveAppUrl(
+			req({ "x-forwarded-host": "public.aeorank.dev", host: "internal.vercel.app" }),
+		);
+		expect(url).toBe("https://public.aeorank.dev");
+	});
+
+	it("falls back to VERCEL_PROJECT_PRODUCTION_URL when deployed with no usable host", () => {
+		process.env.VERCEL_ENV = "production";
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+		process.env.VERCEL_PROJECT_PRODUCTION_URL = "aeorank.vercel.app";
+		expect(resolveAppUrl(req())).toBe("https://aeorank.vercel.app");
+	});
+
+	it("throws when deployed and only a localhost origin can be resolved", () => {
+		process.env.VERCEL_ENV = "production";
+		process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+		expect(() => resolveAppUrl(req({ host: "localhost:3000" }))).toThrow();
+	});
+});

--- a/apps/web/lib/app-url.ts
+++ b/apps/web/lib/app-url.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolve the public origin used to build QStash callback URLs
+ * (`${origin}/api/scan/process`).
+ *
+ * QStash accepts a published job as long as the URL is syntactically valid,
+ * then delivers it asynchronously. If the origin is wrong — most commonly a
+ * stale or localhost `NEXT_PUBLIC_APP_URL` carried into a deployment — the job
+ * is accepted but the callback never lands, so the scan sits at "pending"
+ * forever ("Queued — scan starting soon…"). This helper prevents that class of
+ * silent failure by:
+ *   1. trusting an explicit `NEXT_PUBLIC_APP_URL` unless we're deployed and it
+ *      points at localhost,
+ *   2. otherwise deriving the origin from the incoming request (Vercel forwards
+ *      the real public host via `x-forwarded-host` / `x-forwarded-proto`),
+ *   3. falling back to Vercel's injected production URL,
+ *   4. throwing if it can only resolve a localhost origin while deployed — so
+ *      the caller surfaces an immediate "Failed to enqueue" error instead of a
+ *      five-minute hang.
+ */
+
+function stripTrailingSlashes(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+/** True for hostnames/origins that QStash's cloud workers cannot reach. */
+export function isLocalhostOrigin(value: string): boolean {
+	let host: string;
+	try {
+		host = value.includes("://") ? new URL(value).hostname : value.split(":")[0];
+	} catch {
+		return false;
+	}
+	return (
+		host === "localhost" ||
+		host === "127.0.0.1" ||
+		host === "0.0.0.0" ||
+		host === "::1" ||
+		host.endsWith(".localhost")
+	);
+}
+
+export function resolveAppUrl(request: Request): string {
+	const configured = process.env.NEXT_PUBLIC_APP_URL?.trim();
+	const cleanedConfigured = configured ? stripTrailingSlashes(configured) : "";
+
+	// On Vercel this is always set ("production" | "preview" | "development").
+	// Absent locally, where a localhost origin is expected and fine.
+	const deployed = Boolean(process.env.VERCEL_ENV || process.env.VERCEL);
+
+	// 1. Trust an explicit URL, unless deployed + pointing at localhost.
+	if (cleanedConfigured && !(deployed && isLocalhostOrigin(cleanedConfigured))) {
+		return cleanedConfigured;
+	}
+
+	// 2. Derive from the incoming request. Vercel forwards the real public host.
+	const forwardedHost = request.headers.get("x-forwarded-host");
+	const host = forwardedHost ?? request.headers.get("host");
+	if (host && !isLocalhostOrigin(host)) {
+		const proto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() || "https";
+		return `${proto}://${stripTrailingSlashes(host)}`;
+	}
+
+	// 3. Vercel-injected production URL (no scheme).
+	const vercelHost = process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL;
+	if (vercelHost && !isLocalhostOrigin(vercelHost)) {
+		return `https://${stripTrailingSlashes(vercelHost)}`;
+	}
+
+	// 4. Not deployed: a configured localhost origin is exactly what we want.
+	if (cleanedConfigured && !deployed) {
+		return cleanedConfigured;
+	}
+
+	throw new Error(
+		"Cannot resolve a reachable app URL for the scan callback. " +
+			"Set NEXT_PUBLIC_APP_URL to the deployment's public origin.",
+	);
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"@": fileURLToPath(new URL("./", import.meta.url)),
+		},
+	},
 	test: {
 		environment: "node",
 	},


### PR DESCRIPTION
## Problem

Sites got stuck on **"Queued — scan starting soon…"** and never started indexing. The scan lifecycle depends on QStash delivering a callback to `${NEXT_PUBLIC_APP_URL}/api/scan/process` — the only path that flips a scan `pending → running` and runs it.

QStash **accepts** a published job for any syntactically valid URL, then delivers it asynchronously, so a stale/localhost `NEXT_PUBLIC_APP_URL` fails **silently**: the `scans` row is created, the `/api/scan` call returns 202, the callback never lands, and after 5 minutes `scan/status` marks it `error` ("Scan did not start processing. The job queue may not have delivered the request."). The core scanner is healthy — the daily CLI demo scan of sumhealth.org passes.

## Fix

New `apps/web/lib/app-url.ts` → `resolveAppUrl(request)`, used by both publishers (`/api/scan`, `/api/cron/rescan`) instead of raw `NEXT_PUBLIC_APP_URL`:

1. Trust explicit `NEXT_PUBLIC_APP_URL` — unless deployed (`VERCEL_ENV` set) **and** it points at localhost.
2. Else derive the origin from `x-forwarded-host` / `x-forwarded-proto` (Vercel forwards the real host).
3. Else fall back to `VERCEL_PROJECT_PRODUCTION_URL`.
4. Throw if only a localhost origin resolves while deployed → enqueue fails **immediately** with a clear error instead of a silent 5-minute "Queued" hang.

Also folds in in-progress rescan hardening: `CRON_SECRET` presence check, error surfacing + Sentry in `cron/rescan`, first-run schedule offset, and the vitest `@` alias for route tests.

## Tests

`lib/app-url.test.ts` (8 cases) + existing `cron/rescan/route.test.ts`. Full web suite: **58/58 pass**, typecheck clean.

## Follow-up (config, not code)

Set Production `NEXT_PUBLIC_APP_URL=https://aeorank.dev` in Vercel. The code compensates if it's wrong, but that's still the correct source of truth (also used for Stripe return URLs). If scans still hang after this, check the QStash delivery log for a `401` (signing-key mismatch) vs a connection failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)